### PR TITLE
feat: Add quick sale and purchase from home page

### DIFF
--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -1,4 +1,8 @@
 <div class="container my-5">
+  <div class="d-flex justify-content-end mb-3">
+    <button mat-raised-button color="primary" (click)="openSaleDialog()" class="mr-2">Quick Sale</button>
+    <button mat-raised-button color="accent" (click)="openPurchaseDialog()">Quick Purchase</button>
+  </div>
   <h1 class="text-center mb-4">Dashboard</h1>
   <div class="row mb-4">
       <div class="col-md-12">

--- a/src/app/components/home/home.component.spec.ts
+++ b/src/app/components/home/home.component.spec.ts
@@ -1,59 +1,62 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { of } from 'rxjs';
+import { MatDialog } from '@angular/material/dialog';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { HomeComponent } from './home.component';
 import { HomeService } from './services/home.service';
+import { ProductService } from '../product/services/product.service';
+import { SaleService } from '../sale/services/sale.service';
+import { PurchaseService } from '../purchase/services/purchase.service';
+import { SaleDialogComponent } from '../sale/sale-dialog/sale-dialog.component';
+import { PurchaseDialogComponent } from '../purchase/purchase-dialog/purchase-dialog.component';
 import { DashboardData } from './data/dashboard.model';
+import { Product } from '../product/data/product-model';
+import { Sale } from '../sale/data/sale-model';
+import { Purchase } from '../purchase/data/purchase-model';
 
 describe('HomeComponent', () => {
   let component: HomeComponent;
   let fixture: ComponentFixture<HomeComponent>;
   let homeService: HomeService;
+  let productService: ProductService;
+  let saleService: SaleService;
+  let purchaseService: PurchaseService;
+  let dialog: MatDialog;
 
   const mockDashboardData: DashboardData = {
-    total_sales: {
-      total_count: 10,
-      total_revenue: 2000,
-      total_items_sold: 15,
-    },
+    total_sales: { total_count: 10, total_revenue: 2000, total_items_sold: 15 },
     total_products: 50,
     total_categories: 5,
-    most_sold_items: {
-      '1': {
-        product_name: 'Test Product',
-        product_category: 'Test Category',
-        total_quantity: 5,
-        total_revenue: 500,
-      },
-    },
-    recent_sales: [
-      {
-        id: 1,
-        customer_name: 'Test Customer',
-        customer_address: '123 Test St',
-        customer_mobile: '123-456-7890',
-        date: '2025-01-01',
-        total_quantity: 2,
-        total_price: 200,
-      },
-    ],
+    most_sold_items: {},
+    recent_sales: [],
+    total_purchases: { total_count: 5, total_cost: 1000, total_items_purchased: 10 },
+    recent_purchases: [],
   };
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HomeComponent, HttpClientTestingModule],
-      providers: [HomeService],
+      imports: [HomeComponent, HttpClientTestingModule, NoopAnimationsModule],
+      providers: [
+        HomeService,
+        ProductService,
+        SaleService,
+        PurchaseService,
+        MatDialog,
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(HomeComponent);
     component = fixture.componentInstance;
-    homeService = TestBed.inject(HomeService); // Get the service instance
+    homeService = TestBed.inject(HomeService);
+    productService = TestBed.inject(ProductService);
+    saleService = TestBed.inject(SaleService);
+    purchaseService = TestBed.inject(PurchaseService);
+    dialog = TestBed.inject(MatDialog);
 
-    // Spy on the service method and return mock data
     spyOn(homeService, 'getDashboardData').and.returnValue(of(mockDashboardData));
-
-    fixture.detectChanges(); // This will trigger ngOnInit
+    fixture.detectChanges();
   });
 
   it('should create', () => {
@@ -61,9 +64,51 @@ describe('HomeComponent', () => {
   });
 
   it('should load dashboard data on init', () => {
-    // The spy is set up in beforeEach, and ngOnInit is called by detectChanges.
-    // So, the data should be loaded by the time this test runs.
     expect(homeService.getDashboardData).toHaveBeenCalled();
     expect(component.dashboardData).toEqual(mockDashboardData);
+  });
+
+  it('should open sale dialog, add sale, and reload data', () => {
+    const mockProducts: Product[] = [];
+    const mockSaleResult: Sale = {} as Sale;
+
+    spyOn(productService, 'getProducts').and.returnValue(of(mockProducts));
+    spyOn(dialog, 'open').and.returnValue({
+      afterClosed: () => of(mockSaleResult),
+    } as any);
+    spyOn(saleService, 'addSale').and.returnValue(of(mockSaleResult));
+    spyOn(component, 'loadDashboardData');
+
+    component.openSaleDialog();
+
+    expect(productService.getProducts).toHaveBeenCalled();
+    expect(dialog.open).toHaveBeenCalledWith(SaleDialogComponent, {
+      width: '80%',
+      data: mockProducts,
+    });
+    expect(saleService.addSale).toHaveBeenCalledWith(mockSaleResult);
+    expect(component.loadDashboardData).toHaveBeenCalled();
+  });
+
+  it('should open purchase dialog, add purchase, and reload data', () => {
+    const mockProducts: Product[] = [];
+    const mockPurchaseResult: Purchase = {} as Purchase;
+
+    spyOn(productService, 'getProducts').and.returnValue(of(mockProducts));
+    spyOn(dialog, 'open').and.returnValue({
+      afterClosed: () => of(mockPurchaseResult),
+    } as any);
+    spyOn(purchaseService, 'addPurchase').and.returnValue(of(mockPurchaseResult));
+    spyOn(component, 'loadDashboardData');
+
+    component.openPurchaseDialog();
+
+    expect(productService.getProducts).toHaveBeenCalled();
+    expect(dialog.open).toHaveBeenCalledWith(PurchaseDialogComponent, {
+      width: '80%',
+      data: mockProducts,
+    });
+    expect(purchaseService.addPurchase).toHaveBeenCalledWith(mockPurchaseResult);
+    expect(component.loadDashboardData).toHaveBeenCalled();
   });
 });

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -2,13 +2,20 @@ import { Component, OnInit } from '@angular/core';
 import { DashboardData } from './data/dashboard.model';
 import { HomeService } from './services/home.service';
 import { CommonModule } from '@angular/common';
-
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { ProductService } from '../product/services/product.service';
+import { SaleService } from '../sale/services/sale.service';
+import { PurchaseService } from '../purchase/services/purchase.service';
+import { SaleDialogComponent } from '../sale/sale-dialog/sale-dialog.component';
+import { PurchaseDialogComponent } from '../purchase/purchase-dialog/purchase-dialog.component';
 import { KeyValuePipe } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+
 @Component({
   selector: 'app-home',
   templateUrl: './home.component.html',
   styleUrls: ['./home.component.css'],
-  imports: [CommonModule, KeyValuePipe],
+  imports: [CommonModule, KeyValuePipe, MatDialogModule, MatButtonModule],
   standalone: true,
 })
 export class HomeComponent implements OnInit {
@@ -31,7 +38,13 @@ export class HomeComponent implements OnInit {
     recent_purchases: [],
   };
 
-  constructor(private homeService: HomeService) { }
+  constructor(
+    private homeService: HomeService,
+    private productService: ProductService,
+    private saleService: SaleService,
+    private purchaseService: PurchaseService,
+    public dialog: MatDialog
+  ) { }
 
   ngOnInit(): void {
     this.loadDashboardData();
@@ -40,6 +53,40 @@ export class HomeComponent implements OnInit {
   loadDashboardData(): void {
     this.homeService.getDashboardData().subscribe(data => {
       this.dashboardData = data;
+    });
+  }
+
+  openSaleDialog(): void {
+    this.productService.getProducts().subscribe(products => {
+      const dialogRef = this.dialog.open(SaleDialogComponent, {
+        width: '80%',
+        data: products
+      });
+
+      dialogRef.afterClosed().subscribe(result => {
+        if (result) {
+          this.saleService.addSale(result).subscribe(() => {
+            this.loadDashboardData();
+          });
+        }
+      });
+    });
+  }
+
+  openPurchaseDialog(): void {
+    this.productService.getProducts().subscribe(products => {
+      const dialogRef = this.dialog.open(PurchaseDialogComponent, {
+        width: '80%',
+        data: products
+      });
+
+      dialogRef.afterClosed().subscribe(result => {
+        if (result) {
+          this.purchaseService.addPurchase(result).subscribe(() => {
+            this.loadDashboardData();
+          });
+        }
+      });
     });
   }
 }

--- a/src/app/components/home/services/home.service.ts
+++ b/src/app/components/home/services/home.service.ts
@@ -19,6 +19,12 @@ export class HomeService {
     total_categories: 0,
     most_sold_items: {},
     recent_sales: [],
+    total_purchases: {
+      total_count: 0,
+      total_cost: 0,
+      total_items_purchased: 0,
+    },
+    recent_purchases: [],
   };
 
 


### PR DESCRIPTION
I've introduced a new feature that allows you to perform a "Quick Sale" or "Quick Purchase" directly from the home page dashboard.

The following changes have been made:

- Two new buttons, "Quick Sale" and "Quick Purchase", have been added to the `home.component.html` file.
- The `home.component.ts` has been updated to include the logic for opening the existing `SaleDialogComponent` and `PurchaseDialogComponent`.
- The component now fetches all products and passes them to the dialogs, allowing you to quickly select items for a sale or purchase.
- After a sale or purchase is created, the dashboard automatically refreshes to reflect the new data.
- Added unit tests for the new functionality in `home.component.spec.ts`.

Note: I was unable to run the tests due to limitations in my execution environment. However, I have thoroughly reviewed the code and believe it to be correct.