### PR TITLE
fix: Reset paginator on filter change

### DIFF
--- a/src/app/components/purchase/purchase-dialog/purchase-dialog.component.spec.ts
+++ b/src/app/components/purchase/purchase-dialog/purchase-dialog.component.spec.ts
@@ -79,4 +79,10 @@ describe('PurchaseDialogComponent', () => {
     expect(component.filteredPurchaseItems.length).toBe(1);
     expect(component.filteredPurchaseItems[0].productName).toBe('Apple');
   });
+
+  it('should reset paginator on filter', () => {
+    spyOn(component.paginator, 'firstPage');
+    component.applyFilter({ target: { value: 'test' } } as any);
+    expect(component.paginator.firstPage).toHaveBeenCalled();
+  });
 });

--- a/src/app/components/purchase/purchase-dialog/purchase-dialog.component.ts
+++ b/src/app/components/purchase/purchase-dialog/purchase-dialog.component.ts
@@ -262,6 +262,9 @@ convertProductsToPurchaseItems(): void {
     }
 
     this.filteredPurchaseItems = filteredItems;
+    if (this.paginator) {
+      this.paginator.firstPage();
+    }
     this.updatePagination();
   }
 

--- a/src/app/components/sale/sale-dialog/sale-dialog.component.spec.ts
+++ b/src/app/components/sale/sale-dialog/sale-dialog.component.spec.ts
@@ -79,4 +79,10 @@ describe('SaleDialogComponent', () => {
     expect(component.filteredSaleItems.length).toBe(1);
     expect(component.filteredSaleItems[0].productName).toBe('Apple');
   });
+
+  it('should reset paginator on filter', () => {
+    spyOn(component.paginator, 'firstPage');
+    component.applyFilter({ target: { value: 'test' } } as any);
+    expect(component.paginator.firstPage).toHaveBeenCalled();
+  });
 });

--- a/src/app/components/sale/sale-dialog/sale-dialog.component.ts
+++ b/src/app/components/sale/sale-dialog/sale-dialog.component.ts
@@ -262,6 +262,9 @@ convertProductsToSaleItems(): void {
     }
 
     this.filteredSaleItems = filteredItems;
+    if (this.paginator) {
+      this.paginator.firstPage();
+    }
     this.updatePagination();
   }
 


### PR DESCRIPTION
This commit fixes an issue where the paginator was not being reset when the search or category filter was applied. This could lead to a situation where you would see an empty table even though there were matching results on another page.

The following changes have been made:

- Updated the `applyFilter` method in both the `SaleDialogComponent` and `PurchaseDialogComponent` to reset the paginator to the first page after the filter is applied.
- Added new unit tests to verify that the paginator is reset when the filter is applied.

Note: I could not run the tests due to limitations in my execution environment. However, I have thoroughly reviewed the code and believe it to be correct.