### PR TITLE
feat: display today's sale and purchase summary

### DIFF
--- a/src/app/components/purchase/purchases/purchases.component.css
+++ b/src/app/components/purchase/purchases/purchases.component.css
@@ -23,3 +23,20 @@ h1 {
 .mat-elevation-z8 {
   box-shadow: 0 2px 4px -1px rgba(0,0,0,.2), 0 4px 5px 0 rgba(0,0,0,.14), 0 1px 10px 0 rgba(0,0,0,.12);
 }
+
+.summary-container {
+  margin-bottom: 20px;
+  padding: 15px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  background-color: #f9f9f9;
+}
+
+.summary-container h2 {
+  margin-top: 0;
+}
+
+.summary-details {
+  display: flex;
+  justify-content: space-around;
+}

--- a/src/app/components/purchase/purchases/purchases.component.html
+++ b/src/app/components/purchase/purchases/purchases.component.html
@@ -3,6 +3,16 @@
     <h1>Purchases</h1>
   </div>
 
+  <!-- Today's Purchase Summary -->
+  <div class="summary-container">
+    <h2>Today's Purchase Summary</h2>
+    <div class="summary-details">
+      <p><strong>Total Purchases:</strong> {{ todaysPurchaseSummary.total_count }}</p>
+      <p><strong>Total Cost:</strong> {{ todaysPurchaseSummary.total_cost | currency:'INR' }}</p>
+      <p><strong>Total Items Purchased:</strong> {{ todaysPurchaseSummary.total_items_purchased }}</p>
+    </div>
+  </div>
+
   <div class="filter-container">
     <!-- Category Filter -->
     <mat-form-field appearance="fill">

--- a/src/app/components/purchase/purchases/purchases.component.ts
+++ b/src/app/components/purchase/purchases/purchases.component.ts
@@ -56,6 +56,12 @@ export class PurchasesComponent {
 
   private allPurchases: Purchase[] = [];
 
+  todaysPurchaseSummary = {
+    total_count: 0,
+    total_cost: 0,
+    total_items_purchased: 0,
+  };
+
   constructor(
     private productService: ProductService,
     private categoryService: CategoryService,
@@ -79,7 +85,23 @@ export class PurchasesComponent {
       this.allPurchases = purchases;
       this.dataSource.data = purchases;
       this.dataSource.paginator = this.paginator;
+      this.calculateTodaysPurchaseSummary();
     });
+  }
+
+  calculateTodaysPurchaseSummary(): void {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    const todaysPurchases = this.allPurchases.filter(p => {
+      const purchaseDate = new Date(p.date);
+      purchaseDate.setHours(0, 0, 0, 0);
+      return purchaseDate.getTime() === today.getTime();
+    });
+
+    this.todaysPurchaseSummary.total_count = todaysPurchases.length;
+    this.todaysPurchaseSummary.total_cost = todaysPurchases.reduce((acc, purchase) => acc + purchase.totalPrice, 0);
+    this.todaysPurchaseSummary.total_items_purchased = todaysPurchases.reduce((acc, purchase) => acc + purchase.totalQuantity, 0);
   }
 
   // Called when the category or product filter is changed

--- a/src/app/components/sale/sales/sales.component.css
+++ b/src/app/components/sale/sales/sales.component.css
@@ -23,3 +23,20 @@ h1 {
 .mat-elevation-z8 {
   box-shadow: 0 2px 4px -1px rgba(0,0,0,.2), 0 4px 5px 0 rgba(0,0,0,.14), 0 1px 10px 0 rgba(0,0,0,.12);
 }
+
+.summary-container {
+  margin-bottom: 20px;
+  padding: 15px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  background-color: #f9f9f9;
+}
+
+.summary-container h2 {
+  margin-top: 0;
+}
+
+.summary-details {
+  display: flex;
+  justify-content: space-around;
+}

--- a/src/app/components/sale/sales/sales.component.html
+++ b/src/app/components/sale/sales/sales.component.html
@@ -3,6 +3,16 @@
     <h1>Sales</h1>
   </div>
 
+  <!-- Today's Sale Summary -->
+  <div class="summary-container">
+    <h2>Today's Sale Summary</h2>
+    <div class="summary-details">
+      <p><strong>Total Sales:</strong> {{ todaysSaleSummary.total_count }}</p>
+      <p><strong>Total Revenue:</strong> {{ todaysSaleSummary.total_revenue | currency:'INR' }}</p>
+      <p><strong>Total Items Sold:</strong> {{ todaysSaleSummary.total_items_sold }}</p>
+    </div>
+  </div>
+
   <div class="filter-container">
     <!-- Category Filter -->
     <mat-form-field appearance="fill">

--- a/src/app/components/sale/sales/sales.component.ts
+++ b/src/app/components/sale/sales/sales.component.ts
@@ -56,6 +56,12 @@ export class SalesComponent {
 
   private allSales: Sale[] = [];
 
+  todaysSaleSummary = {
+    total_count: 0,
+    total_revenue: 0,
+    total_items_sold: 0,
+  };
+
   constructor(
     private productService: ProductService,
     private categoryService: CategoryService,
@@ -79,7 +85,23 @@ export class SalesComponent {
       this.allSales = sales;
       this.dataSource.data = sales;
       this.dataSource.paginator = this.paginator;
+      this.calculateTodaysSaleSummary();
     });
+  }
+
+  calculateTodaysSaleSummary(): void {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    const todaysSales = this.allSales.filter(s => {
+      const saleDate = new Date(s.date);
+      saleDate.setHours(0, 0, 0, 0);
+      return saleDate.getTime() === today.getTime();
+    });
+
+    this.todaysSaleSummary.total_count = todaysSales.length;
+    this.todaysSaleSummary.total_revenue = todaysSales.reduce((acc, sale) => acc + sale.totalPrice, 0);
+    this.todaysSaleSummary.total_items_sold = todaysSales.reduce((acc, sale) => acc + sale.totalQuantity, 0);
   }
 
   // Called when the category or product filter is changed


### PR DESCRIPTION
This commit implements a new feature to display a summary of today's sales and purchases on their respective pages.

The following changes have been made:
- In the Sales component, a summary of today's total sales, total revenue, and total items sold is now displayed at the top of the page.
- In the Purchases component, a summary of today's total purchases, total cost, and total items purchased is now displayed at the top of the page.

The summary is calculated in the component's TypeScript file and rendered in the HTML template. Basic styling has been added to the CSS file.

I attempted to run the tests, but was unable to because the test environment lacks a Chrome binary, which prevented the Karma tests from running. The existing tests were basic 'should create' tests. After a manual review of the code and tests, I believe the changes are safe.