### PR TITLE
feat: display today's sale and purchase summary on home page

### DIFF
--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -4,6 +4,57 @@
     <button mat-raised-button color="accent" (click)="openPurchaseDialog()">Quick Purchase</button>
   </div>
   <h1 class="text-center mb-4">Dashboard</h1>
+
+  <!-- Today's Summaries -->
+  <div class="row mb-4">
+    <div class="col-md-6">
+      <div class="card h-100">
+        <div class="card-header bg-info text-white">
+          Today's Sale Summary
+        </div>
+        <div class="card-body">
+          <div class="row text-center">
+            <div class="col-md-4">
+              <h5>Total Sales</h5>
+              <p>{{ todaysSaleSummary.total_count }}</p>
+            </div>
+            <div class="col-md-4">
+              <h5>Total Revenue</h5>
+              <p>{{ todaysSaleSummary.total_revenue | currency:'INR' }}</p>
+            </div>
+            <div class="col-md-4">
+              <h5>Total Items Sold</h5>
+              <p>{{ todaysSaleSummary.total_items_sold }}</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-6">
+      <div class="card h-100">
+        <div class="card-header bg-success text-white">
+          Today's Purchase Summary
+        </div>
+        <div class="card-body">
+          <div class="row text-center">
+            <div class="col-md-4">
+              <h5>Total Purchases</h5>
+              <p>{{ todaysPurchaseSummary.total_count }}</p>
+            </div>
+            <div class="col-md-4">
+              <h5>Total Cost</h5>
+              <p>{{ todaysPurchaseSummary.total_cost | currency:'INR' }}</p>
+            </div>
+            <div class="col-md-4">
+              <h5>Total Items Purchased</h5>
+              <p>{{ todaysPurchaseSummary.total_items_purchased }}</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <div class="row mb-4">
       <div class="col-md-12">
           <section>

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -10,6 +10,8 @@ import { SaleDialogComponent } from '../sale/sale-dialog/sale-dialog.component';
 import { PurchaseDialogComponent } from '../purchase/purchase-dialog/purchase-dialog.component';
 import { KeyValuePipe } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
+import { Sale } from '../sale/data/sale-model';
+import { Purchase } from '../purchase/data/purchase-model';
 
 @Component({
   selector: 'app-home',
@@ -38,6 +40,18 @@ export class HomeComponent implements OnInit {
     recent_purchases: [],
   };
 
+  todaysSaleSummary = {
+    total_count: 0,
+    total_revenue: 0,
+    total_items_sold: 0,
+  };
+
+  todaysPurchaseSummary = {
+    total_count: 0,
+    total_cost: 0,
+    total_items_purchased: 0,
+  };
+
   constructor(
     private homeService: HomeService,
     private productService: ProductService,
@@ -48,12 +62,56 @@ export class HomeComponent implements OnInit {
 
   ngOnInit(): void {
     this.loadDashboardData();
+    this.loadSalesAndCalculateSummary();
+    this.loadPurchasesAndCalculateSummary();
   }
 
   loadDashboardData(): void {
     this.homeService.getDashboardData().subscribe(data => {
       this.dashboardData = data;
     });
+  }
+
+  loadSalesAndCalculateSummary(): void {
+    this.saleService.getSales().subscribe(sales => {
+      this.calculateTodaysSaleSummary(sales);
+    });
+  }
+
+  calculateTodaysSaleSummary(sales: Sale[]): void {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    const todaysSales = sales.filter(s => {
+      const saleDate = new Date(s.date);
+      saleDate.setHours(0, 0, 0, 0);
+      return saleDate.getTime() === today.getTime();
+    });
+
+    this.todaysSaleSummary.total_count = todaysSales.length;
+    this.todaysSaleSummary.total_revenue = todaysSales.reduce((acc, sale) => acc + sale.totalPrice, 0);
+    this.todaysSaleSummary.total_items_sold = todaysSales.reduce((acc, sale) => acc + sale.totalQuantity, 0);
+  }
+
+  loadPurchasesAndCalculateSummary(): void {
+    this.purchaseService.getPurchases().subscribe(purchases => {
+      this.calculateTodaysPurchaseSummary(purchases);
+    });
+  }
+
+  calculateTodaysPurchaseSummary(purchases: Purchase[]): void {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    const todaysPurchases = purchases.filter(p => {
+      const purchaseDate = new Date(p.date);
+      purchaseDate.setHours(0, 0, 0, 0);
+      return purchaseDate.getTime() === today.getTime();
+    });
+
+    this.todaysPurchaseSummary.total_count = todaysPurchases.length;
+    this.todaysPurchaseSummary.total_cost = todaysPurchases.reduce((acc, purchase) => acc + purchase.totalPrice, 0);
+    this.todaysPurchaseSummary.total_items_purchased = todaysPurchases.reduce((acc, purchase) => acc + purchase.totalQuantity, 0);
   }
 
   openSaleDialog(): void {


### PR DESCRIPTION
This commit implements a new feature to display a summary of today's sales and purchases on the home page.

The following changes have been made:
- In the Home component, new cards have been added to display:
  - Today's Sale Summary (total sales, total revenue, total items sold)
  - Today's Purchase Summary (total purchases, total cost, total items purchased)
- The Home component now fetches all sales and purchases and calculates these summaries on the frontend.

This provides you with a quick overview of the current day's activity directly on the dashboard.