### PR TITLE
Fix category filters in multiple components

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -80,6 +80,7 @@
         "test": {
           "builder": "@angular-devkit/build-angular:karma",
           "options": {
+            "karmaConfig": "karma.conf.js",
             "polyfills": [
               "zone.js",
               "zone.js/testing"

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,55 @@
+// Karma configuration file, see link for more information
+// https://karma-runner.github.io/1.0/config/configuration-file.html
+
+module.exports = function (config) {
+  config.set({
+    basePath: '',
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage'),
+      require('@angular-devkit/build-angular/plugins/karma')
+    ],
+    client: {
+      jasmine: {
+        // you can add configuration options for Jasmine here
+        // the possible options are listed at https://jasmine.github.io/api/edge/Configuration.html
+        // for example, you can disable the random execution with `random: false`
+        // or set a specific seed with `seed: 4321`
+      },
+      clearContext: false // leave Jasmine Spec Runner output visible in browser
+    },
+    jasmineHtmlReporter: {
+      suppressAll: true // removes the duplicated traces
+    },
+    coverageReporter: {
+      dir: require('path').join(__dirname, './coverage/ssms-front-end'),
+      subdir: '.',
+      reporters: [
+        { type: 'html' },
+        { type: 'text-summary' }
+      ]
+    },
+    reporters: ['progress', 'kjhtml'],
+    port: 9876,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    autoWatch: true,
+    browsers: ['ChromeHeadlessNoSandbox'],
+    singleRun: true,
+    restartOnFileChange: true,
+    customLaunchers: {
+      ChromeHeadlessNoSandbox: {
+        base: 'Chrome',
+        flags: [
+          '--headless',
+          '--disable-gpu',
+          '--no-sandbox',
+          '--remote-debugging-port=9222'
+        ]
+      }
+    }
+  });
+};

--- a/src/app/components/product/products/products.component.html
+++ b/src/app/components/product/products/products.component.html
@@ -12,7 +12,7 @@
 
   <mat-form-field appearance="fill">
     <mat-label>Filter by category</mat-label>
-    <mat-select (selectionChange)="filterByCategory($event)">
+  <mat-select (selectionChange)="filterByCategory($event.value)">
       <mat-option value="all">All Categories</mat-option>
       <mat-option *ngFor="let category of categories" [value]="category.id">{{ category.name }}</mat-option>
     </mat-select>

--- a/src/app/components/product/products/products.component.ts
+++ b/src/app/components/product/products/products.component.ts
@@ -51,8 +51,7 @@ export class ProductsComponent implements OnInit {
     this.dataSource.filter = filterValue.trim().toLowerCase();
   }
 
-  filterByCategory(event: any) {
-    const categoryId = event.value;
+  filterByCategory(categoryId: any) {
     if (categoryId === 'all') {
       this.dataSource.data = this.allProducts;
     } else {

--- a/src/app/components/purchase/purchases/purchases.component.html
+++ b/src/app/components/purchase/purchases/purchases.component.html
@@ -17,7 +17,7 @@
     <!-- Category Filter -->
     <mat-form-field appearance="fill">
       <mat-label>Category</mat-label>
-      <mat-select [(value)]="selectedCategoryId" (selectionChange)="onFilterChange()">
+      <mat-select [(ngModel)]="selectedCategoryId" (selectionChange)="onFilterChange()">
         <mat-option value="">All Categories</mat-option>
         <mat-option *ngFor="let category of categories" [value]="category.id">
           {{ category.name }}

--- a/src/app/components/sale/sales/sales.component.html
+++ b/src/app/components/sale/sales/sales.component.html
@@ -17,7 +17,7 @@
     <!-- Category Filter -->
     <mat-form-field appearance="fill">
       <mat-label>Category</mat-label>
-      <mat-select [(value)]="selectedCategoryId" (selectionChange)="onFilterChange()">
+    <mat-select [(ngModel)]="selectedCategoryId" (selectionChange)="onFilterChange()">
         <mat-option value="">All Categories</mat-option>
         <mat-option *ngFor="let category of categories" [value]="category.id">
           {{ category.name }}

--- a/src/app/components/stock/stocks/stocks.component.html
+++ b/src/app/components/stock/stocks/stocks.component.html
@@ -20,7 +20,7 @@
   <mat-form-field appearance="fill">
     <mat-label>Filter by category</mat-label>
     <mat-select (selectionChange)="onFilterChange()" [(ngModel)]="selectedCategoryId">
-      <mat-option value="">All Categories</mat-option>
+      <mat-option [value]="null">All Categories</mat-option>
       <mat-option *ngFor="let category of categories" [value]="category.id">{{ category.name }}</mat-option>
     </mat-select>
   </mat-form-field>

--- a/src/app/customer-home/customer-home.component.html
+++ b/src/app/customer-home/customer-home.component.html
@@ -9,7 +9,7 @@
     </div>
     <!-- Category Filter -->
     <div class="col-md-6 mb-2">
-      <select class="form-control" [(ngModel)]="selectedCategory" (change)="applyFilters()">
+      <select class="form-control" [(ngModel)]="selectedCategory" (ngModelChange)="applyFilters()">
         <option value="">All Categories</option>
         <option *ngFor="let category of categories" [value]="category.name">{{ category.name }}</option>
       </select>


### PR DESCRIPTION
This commit addresses non-working category filters in the Products, Stock, Sale, Purchase, and Customer Home components.

The following changes were made:

- **Stock Component:** Corrected a type mismatch by changing the "All Categories" option value to `null` to align with the service expectation of `number | null`.
- **Sales Component:** Fixed an incorrect `[(value)]` binding to `[(ngModel)]` in the category `mat-select`.
- **Purchase Component:** Fixed an incorrect `[(value)]` binding to `[(ngModel)]` in the category `mat-select`.
- **Products Component:** Simplified the event handling for the category filter by passing the selected value directly to the filter function.
- **Customer Home Component:** Changed `(change)` to `(ngModelChange)` for the category filter for more robust event handling.

Additionally, I attempted to run the unit tests. I encountered an issue with the Karma test runner not being able to find a Chrome browser. I configured Karma to use a headless Chrome instance by adding a `karma.conf.js` file and updating `angular.json`. However, the tests still failed to run due to environment constraints.