### PR TITLE
Feat: Display stock and sale values on dashboard

### DIFF
--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -6,6 +6,40 @@
   </div>
   <h1 class="text-center mb-4">Dashboard</h1>
 
+  <!-- Stock and Sale Values -->
+  <div class="row mb-4">
+    <div class="col-md-4">
+      <div class="card h-100">
+        <div class="card-header bg-primary text-white">
+          Total Stock Value
+        </div>
+        <div class="card-body text-center">
+          <h5>{{ totalStockValue | currency:'INR' }}</h5>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-4">
+      <div class="card h-100">
+        <div class="card-header bg-warning text-dark">
+          Projected Sale Value
+        </div>
+        <div class="card-body text-center">
+          <h5>{{ projectedSaleValue | currency:'INR' }}</h5>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-4">
+      <div class="card h-100">
+        <div class="card-header bg-success text-white">
+          Projected Profit
+        </div>
+        <div class="card-body text-center">
+          <h5>{{ projectedProfitValue | currency:'INR' }}</h5>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <!-- Today's Summaries -->
   <div class="row mb-4">
     <div class="col-md-6">

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -23,6 +23,10 @@ import { DayManagementComponent } from '../day-management/day-management.compone
 })
 export class HomeComponent implements OnInit {
 
+  totalStockValue = 0;
+  projectedSaleValue = 0;
+  projectedProfitValue = 0;
+
   dashboardData: DashboardData = {
     total_sales: {
       total_count: 0,
@@ -66,6 +70,7 @@ export class HomeComponent implements OnInit {
     this.loadDashboardData();
     this.loadSalesAndCalculateSummary();
     this.loadPurchasesAndCalculateSummary();
+    this.calculateStockValues();
   }
 
   loadDashboardData(): void {
@@ -153,6 +158,23 @@ export class HomeComponent implements OnInit {
   openDayManagement(): void {
     const dialogRef = this.dialog.open(DayManagementComponent, {
       width: '80%'
+    });
+  }
+
+  calculateStockValues(): void {
+    this.productService.getProducts().subscribe(products => {
+      let totalStock = 0;
+      let projectedSale = 0;
+
+      products.forEach(product => {
+        const totalQuantity = product.sizeMap.reduce((acc, size) => acc + size.quantity, 0);
+        totalStock += totalQuantity * product.unitPrice;
+        projectedSale += totalQuantity * product.sellingPrice;
+      });
+
+      this.totalStockValue = totalStock;
+      this.projectedSaleValue = projectedSale;
+      this.projectedProfitValue = projectedSale - totalStock;
     });
   }
 }


### PR DESCRIPTION
This commit adds a new section to the dashboard to display the following calculated values:
- Total stock value
- Projected total sale value
- Projected profit value

The values are calculated on the frontend by fetching all products and their stock levels.

Changes include:
- Updated `home.component.ts` to calculate the required values.
- Updated `home.component.html` to display the new values in a new set of cards on the dashboard.