### PR TITLE
feat: Load day management data on sales component init

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,5 +1,6 @@
 // Karma configuration file, see link for more information
 // https://karma-runner.github.io/1.0/config/configuration-file.html
+process.env.CHROME_BIN = require('puppeteer').executablePath();
 
 module.exports = function (config) {
   config.set({
@@ -37,19 +38,8 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['ChromeHeadlessNoSandbox'],
+    browsers: ['ChromeHeadless'],
     singleRun: true,
-    restartOnFileChange: true,
-    customLaunchers: {
-      ChromeHeadlessNoSandbox: {
-        base: 'Chrome',
-        flags: [
-          '--headless',
-          '--disable-gpu',
-          '--no-sandbox',
-          '--remote-debugging-port=9222'
-        ]
-      }
-    }
+    restartOnFileChange: true
   });
 };

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "karma-coverage": "~2.2.0",
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.1.0",
+    "puppeteer": "^22.13.1",
     "typescript": "~5.7.2"
   }
 }

--- a/src/app/components/day-management/day-management.service.ts
+++ b/src/app/components/day-management/day-management.service.ts
@@ -12,6 +12,10 @@ export class DayManagementService {
 
   constructor(private http: HttpClient) { }
 
+  getDayStatus(): Observable<any> {
+    return this.http.get(`${this.apiUrl}/status`);
+  }
+
   startDay(openingBalance: number): Observable<any> {
     return this.http.post(`${this.apiUrl}/start`, { openingBalance });
   }

--- a/src/app/components/sale/sales/sales.component.ts
+++ b/src/app/components/sale/sales/sales.component.ts
@@ -17,6 +17,8 @@ import { AppState } from 'src/app/store/app.state';
 import { selectDayStarted } from 'src/app/store/selectors/day.selectors';
 import { Observable } from 'rxjs';
 import { NgxPaginationModule } from 'ngx-pagination';
+import { DayManagementService } from '../../day-management/day-management.service';
+import { loadDayState } from 'src/app/store/actions/day.actions';
 
 @Component({
   selector: 'app-sales',
@@ -56,12 +58,14 @@ export class SalesComponent {
     private categoryService: CategoryService,
     private dialog: MatDialog,
     private saleService: SaleService,
+    private dayManagementService: DayManagementService,
     private store: Store<AppState>
   ) {
     this.isDayStarted$ = this.store.select(selectDayStarted);
   }
 
   ngOnInit(): void {
+    this.store.dispatch(loadDayState());
     this.categoryService.getCategories().subscribe(categories => {
       this.categories = categories;
     });

--- a/src/app/store/actions/day.actions.ts
+++ b/src/app/store/actions/day.actions.ts
@@ -8,3 +8,17 @@ export const startDay = createAction(
 export const endDay = createAction(
   '[Day] End Day'
 );
+
+export const loadDayState = createAction(
+  '[Day] Load Day State'
+);
+
+export const loadDayStateSuccess = createAction(
+  '[Day] Load Day State Success',
+  props<{ dayStarted: boolean; openingBalance: number }>()
+);
+
+export const loadDayStateFailure = createAction(
+  '[Day] Load Day State Failure',
+  props<{ error: any }>()
+);

--- a/src/app/store/reducers/day.reducer.ts
+++ b/src/app/store/reducers/day.reducer.ts
@@ -1,5 +1,5 @@
 import { createReducer, on } from '@ngrx/store';
-import { startDay, endDay } from '../actions/day.actions';
+import { startDay, endDay, loadDayStateSuccess } from '../actions/day.actions';
 
 export interface DayState {
   dayStarted: boolean;
@@ -21,5 +21,10 @@ export const dayReducer = createReducer(
   on(endDay, (state) => ({
     ...state,
     dayStarted: false,
+  })),
+  on(loadDayStateSuccess, (state, { dayStarted, openingBalance }) => ({
+    ...state,
+    dayStarted,
+    openingBalance,
   }))
 );


### PR DESCRIPTION
- Added actions to load day state (`loadDayState`, `loadDayStateSuccess`, `loadDayStateFailure`).
- Updated the day reducer to handle `loadDayStateSuccess`.
- Added `getDayStatus` method to `DayManagementService` to fetch day status.
- Dispatched `loadDayState` action in `SalesComponent` on initialization.
- This ensures that the day management data is available when the sales component is loaded.