### PR TITLE
fix(deps): add missing @ngrx/effects dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@angular/router": "^19.1.0",
     "@angular/ssr": "^19.1.4",
     "@ngrx/store": "^19.1.0",
+    "@ngrx/effects": "^19.1.0",
     "bootstrap": "^5.3.6",
     "express": "^4.18.2",
     "file-saver": "^2.0.5",


### PR DESCRIPTION
The application was failing with a "TypeError: Cannot read properties of undefined (reading 'pipe')" in `day.effects.ts`. This was caused by the `Actions` service from NgRx Effects not being injected correctly.

The root cause was the missing `@ngrx/effects` package in the `package.json` dependencies. This change adds the required dependency.