### PR TITLE
refactor(effects): use inject() for dependency injection in DayEffects

### DIFF
--- a/src/app/store/effects/day.effects.ts
+++ b/src/app/store/effects/day.effects.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { DayManagementService } from 'src/app/components/day-management/day-management.service';
 import { loadDayState, loadDayStateSuccess, loadDayStateFailure } from '../actions/day.actions';
@@ -7,10 +7,8 @@ import { of } from 'rxjs';
 
 @Injectable()
 export class DayEffects {
-  constructor(
-    private actions$: Actions,
-    private dayManagementService: DayManagementService
-  ) {}
+  private actions$ = inject(Actions);
+  private dayManagementService = inject(DayManagementService);
 
   loadDayState$ = createEffect(() =>
     this.actions$.pipe(


### PR DESCRIPTION
The previous approach of using constructor injection for the `Actions` service in `DayEffects` was failing, likely in a server-side rendering (SSR) context, causing a "TypeError: Cannot read properties of undefined (reading 'pipe')".

This change refactors `DayEffects` to use the `inject()` function from `@angular/core`. This is a more modern and robust way to handle dependency injection in Angular and should resolve the runtime error.