### PR TITLE
I've updated the "Order via WhatsApp" feature. The message generated …

### DIFF
--- a/src/app/customer-home/customer-home.component.spec.ts
+++ b/src/app/customer-home/customer-home.component.spec.ts
@@ -1,0 +1,75 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CustomerHomeComponent } from './customer-home.component';
+import { CustomerHomeService } from './services/customer-view.service';
+import { of } from 'rxjs';
+import { Product } from '../components/product/data/product-model';
+import { FormsModule } from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { NgxPaginationModule } from 'ngx-pagination';
+import { environment } from 'src/environment';
+
+describe('CustomerHomeComponent', () => {
+  let component: CustomerHomeComponent;
+  let fixture: ComponentFixture<CustomerHomeComponent>;
+  let customerHomeService: jasmine.SpyObj<CustomerHomeService>;
+
+  beforeEach(async () => {
+    const customerHomeServiceSpy = jasmine.createSpyObj('CustomerHomeService', ['getHomeData']);
+
+    await TestBed.configureTestingModule({
+      imports: [
+        FormsModule,
+        CommonModule,
+        NgxPaginationModule,
+        CustomerHomeComponent
+      ],
+      providers: [
+        { provide: CustomerHomeService, useValue: customerHomeServiceSpy }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CustomerHomeComponent);
+    component = fixture.componentInstance;
+    customerHomeService = TestBed.inject(CustomerHomeService) as jasmine.SpyObj<CustomerHomeService>;
+
+    // Mock the getHomeData method
+    const mockProducts: Product[] = [];
+    customerHomeService.getHomeData.and.returnValue(of({ products: mockProducts }));
+
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should open WhatsApp with correct message including image URL', () => {
+    const mockProduct: Product = {
+      id: 1,
+      name: 'Test Product',
+      description: 'Test Description',
+      category: { id: 1, name: 'Test Category', description: '' },
+      categoryId: 1,
+      sizeMap: [{ size: 'M', quantity: 10 }],
+      unitPrice: 100,
+      sellingPrice: 150,
+      imageUrl: 'test-image.jpg',
+      isActive: true,
+      canListed: true,
+      offerId: '',
+      discountedPrice: 0,
+      offerPrice: 0
+    };
+
+    component.selectedSize = 'M';
+    spyOn(window, 'open').and.stub();
+
+    component.orderViaWhatsApp(mockProduct);
+
+    const expectedImageUrl = `${environment.apiUrl}/${mockProduct.imageUrl}`;
+    const message = encodeURIComponent(`Hello, I would like to order ${mockProduct.name} with selected size M at ${mockProduct.sellingPrice}.\nImage: ${expectedImageUrl}`);
+    const expectedUrl = `https://api.whatsapp.com/send?phone=+918089325733&text=${message}`;
+
+    expect(window.open).toHaveBeenCalledWith(expectedUrl, '_blank');
+  });
+});

--- a/src/app/customer-home/customer-home.component.ts
+++ b/src/app/customer-home/customer-home.component.ts
@@ -94,8 +94,15 @@ const categoryMap = new Map<string, Category>();
       alert('Please select a size before ordering.');
       return;
     }
-    const message = encodeURIComponent(`Hello, I would like to order ${product.name} with selected size ${this.selectedSize} at ${product.sellingPrice}.`);
-    // Replace the phone number with your WhatsApp number
+
+    let messageBody = `Hello, I would like to order ${product.name} with selected size ${this.selectedSize} at ${product.sellingPrice}.`;
+
+    if (product.imageUrl) {
+      const imageUrl = `${environment.apiUrl}/${product.imageUrl}`;
+      messageBody += `\nImage: ${imageUrl}`;
+    }
+
+    const message = encodeURIComponent(messageBody);
     const url = `https://api.whatsapp.com/send?phone=+918089325733&text=${message}`;
     window.open(url, '_blank');
     this.closeBuyModal();


### PR DESCRIPTION
…when you click the button will now include the product image URL.

Here are the changes I made:
- I modified the `orderViaWhatsApp` function in `customer-home.component.ts` to append the product image URL to the message.
- I constructed the image URL using the `apiUrl` from the environment file.
- I added a unit test to verify that the WhatsApp message is correctly formatted and includes the image URL.