### PR TITLE
feat(events-offers): Add image upload functionality for events and of…

### DIFF
--- a/src/app/components/events-offers/data/events-offers-model.ts
+++ b/src/app/components/events-offers/data/events-offers-model.ts
@@ -14,6 +14,7 @@ export interface EventOffer {
   endDate: string;
   rateType: 'flat' | 'percentage';
   rate: number;
+  imageUrl?: string;
 }
 
 export interface Participant {

--- a/src/app/components/events-offers/events-offers-dialog/events-offers-dialog.component.html
+++ b/src/app/components/events-offers/events-offers-dialog/events-offers-dialog.component.html
@@ -12,6 +12,15 @@
       <textarea matInput formControlName="description"></textarea>
     </mat-form-field>
 
+    <div class="mb-3">
+      <label for="imageUpload" class="form-label">Choose File</label>
+      <input type="file" id="imageUpload" class="form-control" (change)="onImageChange($event)" accept="image/*">
+    </div>
+    <div *ngIf="imagePreview" class="mb-3">
+      <p><strong>Selected Image Preview:</strong></p>
+      <img [src]="imagePreview" alt="Image Preview" class="img-fluid" style="max-height: 200px;">
+    </div>
+
     <mat-form-field>
       <mat-label>Type</mat-label>
       <mat-select formControlName="type">

--- a/src/app/components/events-offers/events-offers-list/events-offers-list.component.html
+++ b/src/app/components/events-offers/events-offers-list/events-offers-list.component.html
@@ -23,6 +23,14 @@
       <td mat-cell *matCellDef="let element"> {{element.name}} </td>
     </ng-container>
 
+    <!-- Image Column -->
+    <ng-container matColumnDef="imageUrl">
+      <th mat-header-cell *matHeaderCellDef> Image </th>
+      <td mat-cell *matCellDef="let element">
+        <img *ngIf="element.imageUrl" [src]="element.imageUrl" alt="{{element.name}}" width="50">
+      </td>
+    </ng-container>
+
        <!-- Description Column -->
     <ng-container matColumnDef="description">
       <th mat-header-cell *matHeaderCellDef> Description </th>

--- a/src/app/components/events-offers/events-offers-list/events-offers-list.component.ts
+++ b/src/app/components/events-offers/events-offers-list/events-offers-list.component.ts
@@ -32,7 +32,7 @@ import { EventsOffersDialogComponent } from '../events-offers-dialog/events-offe
   styleUrls: ['./events-offers-list.component.css']
 })
 export class EventsOffersListComponent implements OnInit {
-  displayedColumns: string[] = ['id', 'name', 'description', 'type', 'startDate', 'endDate', 'rateType', 'rate', 'isActive', 'actions'];
+  displayedColumns: string[] = ['id', 'name', 'imageUrl', 'description', 'type', 'startDate', 'endDate', 'rateType', 'rate', 'isActive', 'actions'];
   dataSource = new MatTableDataSource<EventOffer>([]);
 
   @ViewChild(MatPaginator) paginator!: MatPaginator;
@@ -66,27 +66,7 @@ export class EventsOffersListComponent implements OnInit {
 
     dialogRef.afterClosed().subscribe(result => {
       if (result) {
-        // convert to snackecase from camelCase
-        const eventOfferObject = {
-          id: result.id || null,
-          name: result.name,
-          description: result.description,
-          type: result.type,
-          is_active: result.isActive,
-          start_date: result.startDate,
-          end_date: result.endDate,
-          rate_type: result.rateType,
-          rate: result.rate,
-          product_ids: result.productIds || [],
-          category_ids: result.categoryIds || []
-        };
-        if (result.id) {
-          // Update
-          this.eventsOffersService.updateEventOffer(eventOfferObject).subscribe(() => this.loadEventOffers());
-        } else {
-          // Create
-          this.eventsOffersService.addEventOffer(eventOfferObject).subscribe(() => this.loadEventOffers());
-        }
+        this.loadEventOffers();
       }
     });
   }

--- a/src/app/components/events-offers/services/events-offers.service.ts
+++ b/src/app/components/events-offers/services/events-offers.service.ts
@@ -27,7 +27,8 @@ export class EventsOffersService {
         startDate: offer.start_date,
         endDate: offer.end_date,
         products: offer.products || [],
-        categories: offer.categories || []
+        categories: offer.categories || [],
+        imageUrl: offer.image_url || ''
       }))
     )
   );
@@ -63,5 +64,11 @@ export class EventsOffersService {
 
   updateWhatsappGroup(eventOfferId: number, message: string): Observable<any> {
     return this.http.post<any>(`${this.apiUrl}/${eventOfferId}/update-whatsapp-group`, { message });
+  }
+
+  uploadEventOfferImage(eventOfferId: number, image: File): Observable<any> {
+    const formData = new FormData();
+    formData.append('image', image, image.name);
+    return this.http.post<any>(`${this.apiUrl}/upload-image?event_offer_id=${eventOfferId}`, formData);
   }
 }


### PR DESCRIPTION
…fers

I've introduced the ability for you to upload an image when creating or editing an event or offer.

The following changes were made:
- Modified the `EventOffer` model to include an `imageUrl` property.
- Updated the `events-offers-dialog` to include a file input for image selection and a preview of the selected image.
- The dialog component now handles the two-step process of saving the event/offer data and then uploading the image.
- The `onSave` method in the dialog now correctly converts the form data from camelCase to snake_case before sending it to the server.
- A new `uploadEventOfferImage` method was added to the `events-offers.service.ts` to handle the image upload. The redundant data fetching call from this method was removed.
- The `events-offers-list` component was updated to display the uploaded image for each event/offer.