### PR TITLE
Refactor dialog components to use Angular Material

### DIFF
--- a/src/app/components/product/product-detail-dialog/product-detail-dialog.component.css
+++ b/src/app/components/product/product-detail-dialog/product-detail-dialog.component.css
@@ -1,0 +1,30 @@
+.view-mode {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.image-container {
+  text-align: center;
+  margin-bottom: 16px;
+}
+
+.product-image {
+  max-width: 100%;
+  max-height: 300px;
+  border-radius: 4px;
+}
+
+.details-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+mat-form-field {
+  width: 100%;
+}
+
+[mat-dialog-actions] {
+  justify-content: flex-end;
+}

--- a/src/app/components/product/product-detail-dialog/product-detail-dialog.component.html
+++ b/src/app/components/product/product-detail-dialog/product-detail-dialog.component.html
@@ -1,65 +1,65 @@
-<div class="modal-header">
-  <h4 class="modal-title">{{ data.product.name }}</h4>
-  <button type="button" class="btn-close" aria-label="Close" (click)="onClose()"></button>
-</div>
-<div class="modal-body">
+<h1 mat-dialog-title>{{ data.product.name }}</h1>
+
+<div mat-dialog-content>
   <!-- View Mode -->
-  <div *ngIf="!editMode">
-    <div *ngIf="data.product.imageUrl">
+  <div *ngIf="!editMode" class="view-mode">
+    <div *ngIf="data.product.imageUrl" class="image-container">
       <img [src]="data.product.imageUrl" alt="{{ data.product.name }}" class="product-image">
     </div>
-    <p><strong>Category:</strong> {{ data.product.category.name }}</p>
+    <div class="details-grid">
+      <p><strong>Category:</strong> {{ data.product.category.name }}</p>
+      <p><strong>Unit Price:</strong> {{ data.product.unitPrice | currency:'INR' }}</p>
+      <p><strong>Selling Price:</strong> {{ data.product.sellingPrice | currency:'INR' }}</p>
+      <p><strong>Discounted Price:</strong> {{ data.product.discountedPrice | currency:'INR' }}</p>
+      <p><strong>Active:</strong> {{ data.product.isActive ? 'Yes' : 'No' }}</p>
+      <p><strong>Can be Listed:</strong> {{ data.product.canListed ? 'Yes' : 'No' }}</p>
+    </div>
     <p><strong>Description:</strong> {{ data.product.description }}</p>
     <p><strong>Sizes:</strong>
       <span *ngFor="let size of data.product.sizeMap; let last = last">
         {{ size.size }}:{{ size.quantity }}<span *ngIf="!last">, </span>
       </span>
-    <p><strong>Unit Price:</strong> {{ data.product.unitPrice | currency:'INR' }}</p>
-    <p><strong>Selling Price:</strong> {{ data.product.sellingPrice | currency:'INR' }}</p>
-    <p><strong>Discounted Price:</strong> {{ data.product.discountedPrice | currency:'INR' }}</p>
-    <p><strong>Active:</strong> {{ data.product.isActive ? 'Yes' : 'No' }}</p>
-    <p><strong>Can be Listed:</strong> {{ data.product.canListed ? 'Yes' : 'No' }}</p>
+    </p>
   </div>
 
   <!-- Edit Mode -->
-  <div *ngIf="editMode">
-    <form [formGroup]="editForm">
-      <div class="mb-3">
-        <label for="category" class="form-label">Category</label>
-        <input type="text" id="category" class="form-control" formControlName="category">
-      </div>
-      <div class="mb-3">
-        <label for="unitPrice" class="form-label">Unit Price</label>
-        <input type="number" id="unitPrice" class="form-control" formControlName="unitPrice">
-      </div>
-      <div class="mb-3">
-        <label for="sellingPrice" class="form-label">Selling Price</label>
-        <input type="number" id="sellingPrice" class="form-control" formControlName="sellingPrice">
-      </div>
-      <div class="mb-3">
-        <label for="isActive" class="form-label">Active</label>
-        <select id="isActive" class="form-select" formControlName="isActive">
-          <option [value]="true">Yes</option>
-          <option [value]="false">No</option>
-        </select>
-      </div>
-      <div class="mb-3">
-        <label for="canListed" class="form-label">Can be Listed</label>
-        <select id="canListed" class="form-select" formControlName="canListed">
-          <option [value]="true">Yes</option>
-          <option [value]="false">No</option>
-        </select>
-      </div>
-    </form>
+  <div *ngIf="editMode" [formGroup]="editForm">
+    <mat-form-field>
+      <mat-label>Category</mat-label>
+      <input matInput formControlName="category">
+    </mat-form-field>
+    <mat-form-field>
+      <mat-label>Unit Price</mat-label>
+      <input matInput type="number" formControlName="unitPrice">
+    </mat-form-field>
+    <mat-form-field>
+      <mat-label>Selling Price</mat-label>
+      <input matInput type="number" formControlName="sellingPrice">
+    </mat-form-field>
+    <mat-form-field>
+      <mat-label>Active</mat-label>
+      <mat-select formControlName="isActive">
+        <mat-option [value]="true">Yes</mat-option>
+        <mat-option [value]="false">No</mat-option>
+      </mat-select>
+    </mat-form-field>
+    <mat-form-field>
+      <mat-label>Can be Listed</mat-label>
+      <mat-select formControlName="canListed">
+        <mat-option [value]="true">Yes</option>
+        <mat-option [value]="false">No</mat-option>
+      </mat-select>
+    </mat-form-field>
   </div>
 </div>
-<div class="modal-footer">
-  <div *ngIf="!editMode">
-    <button class="btn btn-primary" (click)="toggleEditMode()">Edit</button>
-    <button class="btn btn-secondary" (click)="onClose()">Close</button>
-  </div>
-  <div *ngIf="editMode">
-    <button class="btn btn-success" (click)="onUpdate()">Save</button>
-    <button class="btn btn-warning" (click)="toggleEditMode()">Cancel</button>
-  </div>
+
+<div mat-dialog-actions>
+  <ng-container *ngIf="!editMode">
+    <button mat-raised-button color="primary" (click)="toggleEditMode()">Edit</button>
+    <button mat-button (click)="onClose()">Close</button>
+  </ng-container>
+  <ng-container *ngIf="editMode">
+    <button mat-raised-button color="primary" (click)="onUpdate()" [disabled]="editForm.invalid">Save</button>
+    <button mat-button (click)="toggleEditMode()">Cancel</button>
+  </ng-container>
 </div>

--- a/src/app/components/product/product-detail-dialog/product-detail-dialog.component.ts
+++ b/src/app/components/product/product-detail-dialog/product-detail-dialog.component.ts
@@ -1,19 +1,30 @@
 import { CommonModule } from '@angular/common';
 import { Component, Inject } from '@angular/core';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { MAT_DIALOG_DATA, MatDialogRef, MatDialogModule } from '@angular/material/dialog';
 import { Product } from '../data/product-model';
 import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
 
 @Component({
   selector: 'app-product-detail-dialog',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule],
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatDialogModule,
+    MatButtonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule
+  ],
   templateUrl: './product-detail-dialog.component.html',
   styleUrls: ['./product-detail-dialog.component.css']
 })
 export class ProductDetailDialogComponent {
-
-  editMode: boolean = false;
+  editMode = false;
   editForm: FormGroup;
 
   constructor(
@@ -31,8 +42,9 @@ export class ProductDetailDialogComponent {
   }
 
   toggleEditMode(): void {
-    if (this.editMode) {
-      this.editForm.patchValue({
+    this.editMode = !this.editMode;
+    if (!this.editMode) {
+      this.editForm.reset({
         category: this.data.product.category?.name,
         unitPrice: this.data.product.unitPrice,
         sellingPrice: this.data.product.sellingPrice,
@@ -40,15 +52,16 @@ export class ProductDetailDialogComponent {
         canListed: this.data.product.canListed
       });
     }
-    this.editMode = !this.editMode;
   }
 
   onUpdate(): void {
-    const updatedProduct = {
-      ...this.data.product,
-      ...this.editForm.value
-    };
-    this.dialogRef.close(updatedProduct);
+    if (this.editForm.valid) {
+      const updatedProduct = {
+        ...this.data.product,
+        ...this.editForm.value
+      };
+      this.dialogRef.close(updatedProduct);
+    }
   }
 
   onClose(): void {

--- a/src/app/components/product/update-image-dialog/update-image-dialog.component.css
+++ b/src/app/components/product/update-image-dialog/update-image-dialog.component.css
@@ -1,17 +1,21 @@
-.file-input-container {
+.image-upload-container {
   display: flex;
   align-items: center;
   gap: 16px;
+  margin-bottom: 16px;
 }
 
 .file-name {
   font-style: italic;
 }
 
-mat-dialog-actions {
-  padding-top: 16px;
+.image-preview-container {
+  margin-top: 16px;
+  text-align: center;
 }
 
-button {
-  margin-left: 8px;
+.image-preview {
+  max-width: 100%;
+  max-height: 300px;
+  border-radius: 4px;
 }

--- a/src/app/components/product/update-image-dialog/update-image-dialog.component.html
+++ b/src/app/components/product/update-image-dialog/update-image-dialog.component.html
@@ -1,20 +1,19 @@
-<div class="modal-header">
-  <h4 class="modal-title">Update Product Image</h4>
-  <button type="button" class="btn-close" aria-label="Close" (click)="onCancel()"></button>
+<h1 mat-dialog-title>Update Product Image</h1>
+
+<div mat-dialog-content>
+  <div class="image-upload-container">
+    <button type="button" mat-stroked-button (click)="fileInput.click()">Choose File</button>
+    <input hidden (change)="onImageChange($event)" #fileInput type="file" accept="image/*">
+    <span *ngIf="selectedImage" class="file-name">{{ selectedImage.name }}</span>
+  </div>
+
+  <div *ngIf="imagePreview" class="image-preview-container">
+    <p><strong>Selected Image Preview:</strong></p>
+    <img [src]="imagePreview" alt="Image Preview" class="image-preview">
+  </div>
 </div>
-<div class="modal-body">
-  <form [formGroup]="imageForm">
-    <div class="mb-3">
-      <label for="imageUpload" class="form-label">Choose File</label>
-      <input type="file" id="imageUpload" class="form-control" (change)="onImageChange($event)" accept="image/*">
-    </div>
-    <div *ngIf="selectedImage" class="mb-3">
-      <p><strong>Selected Image Preview:</strong></p>
-      <img [src]="imagePreview" alt="Image Preview" class="img-fluid" style="max-height: 200px;">
-    </div>
-  </form>
-</div>
-<div class="modal-footer">
-  <button type="button" class="btn btn-secondary" (click)="onCancel()">Cancel</button>
-  <button type="button" class="btn btn-primary" (click)="onSave()" [disabled]="!selectedImage">Save</button>
+
+<div mat-dialog-actions>
+  <button mat-button (click)="onCancel()">Cancel</button>
+  <button mat-raised-button color="primary" (click)="onSave()" [disabled]="!selectedImage">Save</button>
 </div>

--- a/src/app/components/product/update-image-dialog/update-image-dialog.component.ts
+++ b/src/app/components/product/update-image-dialog/update-image-dialog.component.ts
@@ -1,29 +1,27 @@
 import { Component, Inject } from '@angular/core';
-import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { MatDialogRef, MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
 import { CommonModule } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
 
 @Component({
   selector: 'app-update-image-dialog',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule],
+  imports: [
+    CommonModule,
+    MatDialogModule,
+    MatButtonModule
+  ],
   templateUrl: './update-image-dialog.component.html',
   styleUrls: ['./update-image-dialog.component.css']
 })
 export class UpdateImageDialogComponent {
-  imageForm: FormGroup;
   selectedImage: File | null = null;
   imagePreview: string | ArrayBuffer | null = null;
 
   constructor(
-    private fb: FormBuilder,
     public dialogRef: MatDialogRef<UpdateImageDialogComponent>,
     @Inject(MAT_DIALOG_DATA) public data: any
-  ) {
-    this.imageForm = this.fb.group({
-      image: [null]
-    });
-  }
+  ) {}
 
   onImageChange(event: any): void {
     const file = event.target.files[0];

--- a/src/app/components/product/update-quantity-dialog/update-quantity-dialog.component.css
+++ b/src/app/components/product/update-quantity-dialog/update-quantity-dialog.component.css
@@ -1,23 +1,20 @@
-.size-container {
+.sizes-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 16px;
+}
+
+.size-field {
+  width: 100%;
+}
+
+.custom-size-row {
   display: flex;
-  flex-wrap: wrap;
+  align-items: center;
   gap: 16px;
   margin-bottom: 16px;
 }
 
-.size-input {
-  flex: 1 1 calc(33.333% - 16px);
-  min-width: 120px;
-}
-
-mat-form-field {
-  width: 100%;
-}
-
-mat-dialog-actions {
-  padding-top: 16px;
-}
-
-button {
-  margin-left: 8px;
+.custom-size-row mat-form-field {
+  flex-grow: 1;
 }

--- a/src/app/components/product/update-quantity-dialog/update-quantity-dialog.component.html
+++ b/src/app/components/product/update-quantity-dialog/update-quantity-dialog.component.html
@@ -1,49 +1,37 @@
-<div class="modal-header">
-  <h4 class="modal-title">Update Product Quantity</h4>
-  <button type="button" class="btn-close" aria-label="Close" (click)="onCancel()"></button>
-</div>
-<div class="modal-body">
-  <!-- Standard Sizes -->
-  <h5>Standard Sizes</h5>
-  <div class="row g-3">
-    <div *ngFor="let size of quantities.sizes" class="col-md-4">
-      <label [for]="'size' + size" class="form-label">{{ size }} Quantity</label>
-      <input [id]="'size' + size" type="number" class="form-control" [(ngModel)]="quantities[size]" placeholder="Enter quantity">
-    </div>
+<h1 mat-dialog-title>Update Product Quantity for {{ data.product.name }}</h1>
+
+<div mat-dialog-content [formGroup]="quantityForm">
+  <h2>Standard Sizes</h2>
+  <div formGroupName="standardSizes" class="sizes-grid">
+    <mat-form-field *ngFor="let size of standardSizes" class="size-field">
+      <mat-label>{{ size }} Quantity</mat-label>
+      <input matInput type="number" [formControlName]="size">
+    </mat-form-field>
   </div>
 
   <hr>
 
-  <!-- Custom Sizes -->
-  <h5>Add Custom Size</h5>
-  <div class="row g-3 align-items-end">
-    <div class="col-md-5">
-      <label for="newSizeName" class="form-label">Size Name</label>
-      <input id="newSizeName" type="text" class="form-control" [(ngModel)]="newSizeName" placeholder="Enter size name">
-    </div>
-    <div class="col-md-5">
-      <label for="newSizeQuantity" class="form-label">Quantity</label>
-      <input id="newSizeQuantity" type="number" class="form-control" [(ngModel)]="newSizeQuantity" placeholder="Enter quantity">
-    </div>
-    <div class="col-md-2">
-      <button type="button" class="btn btn-success" (click)="addCustomSize()">Add</button>
+  <h2>Custom Sizes</h2>
+  <div formArrayName="customSizes">
+    <div *ngFor="let group of customSizes.controls; let i = index" [formGroupName]="i" class="custom-size-row">
+      <mat-form-field>
+        <mat-label>Size Name</mat-label>
+        <input matInput formControlName="size">
+      </mat-form-field>
+      <mat-form-field>
+        <mat-label>Quantity</mat-label>
+        <input matInput type="number" formControlName="quantity">
+      </mat-form-field>
+      <button mat-icon-button color="warn" (click)="removeCustomSize(i)">
+        <mat-icon>remove_circle</mat-icon>
+      </button>
     </div>
   </div>
 
-  <!-- Display Custom Sizes -->
-  <div *ngIf="quantities.customSizes.length > 0" class="mt-3">
-    <h5>Custom Sizes</h5>
-    <div *ngFor="let customSize of quantities.customSizes; let i = index" class="row g-3 mb-2">
-      <div class="col-md-5">
-        <input type="text" class="form-control" [(ngModel)]="customSize.size" disabled>
-      </div>
-      <div class="col-md-5">
-        <input type="number" class="form-control" [(ngModel)]="customSize.quantity">
-      </div>
-    </div>
-  </div>
+  <button mat-stroked-button color="primary" (click)="addCustomSize()">Add Custom Size</button>
 </div>
-<div class="modal-footer">
-  <button type="button" class="btn btn-secondary" (click)="onCancel()">Cancel</button>
-  <button type="button" class="btn btn-primary" (click)="onSave()">Save</button>
+
+<div mat-dialog-actions>
+  <button mat-button (click)="onCancel()">Cancel</button>
+  <button mat-raised-button color="primary" (click)="onSave()" [disabled]="quantityForm.invalid">Save</button>
 </div>


### PR DESCRIPTION
The following components have been refactored to use Angular Material components instead of Bootstrap modals, to be consistent with the `ProductDialogComponent`:

- `UpdateQuantityDialogComponent`
- `UpdateImageDialogComponent`
- `ProductDetailDialogComponent`

This change includes:
- Updating the HTML templates to use `mat-dialog`, `mat-form-field`, `mat-input`, `mat-button`, and `mat-select`.
- Converting `UpdateQuantityDialogComponent` from a template-driven form to a reactive form.
- Updating the TypeScript files to import the necessary Angular Material modules.
- Updating the CSS files to style the new components.